### PR TITLE
Set ESLint require-await rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   "rules": {
     "no-console": "off",
     "class-methods-use-this": "off",
+    "require-await": "error",
 
     "jsdoc/check-param-names": "error",
     "jsdoc/check-tag-names": "error",


### PR DESCRIPTION
ESLint will throw an error when a function/method is async but doesn't contain await. This enforces sync methods to truly be sync.