### PR TITLE
Handler now checks against prototype instead of object instance

### DIFF
--- a/src/handler/Event.js
+++ b/src/handler/Event.js
@@ -5,6 +5,9 @@ class Event {
    */
   constructor(eventName) {
     this.eventName = eventName;
+
+    // Category will be assigned by the Handler
+    this.category = null;
   }
 
   /**

--- a/src/handler/Handler.js
+++ b/src/handler/Handler.js
@@ -63,6 +63,7 @@ class Handler {
             this.loadCommand(command);
           } else if (CommandOrEvent.prototype instanceof Event) {
             const event = new CommandOrEvent(dependencies);
+            event.category = category;
 
             this.loadEvent(event);
           }

--- a/src/handler/Handler.js
+++ b/src/handler/Handler.js
@@ -56,24 +56,15 @@ class Handler {
           // eslint-disable-next-line global-require, import/no-dynamic-require
           const CommandOrEvent = require(file);
 
-          // Try to instantiate the command or event, throw an error if it fails
-          let commandOrEvent;
-          try {
-            commandOrEvent = new CommandOrEvent(dependencies);
-          } catch (err) {
-            // TODO: add a debug message here?
-            return;
-          }
+          if (CommandOrEvent.prototype instanceof Command) {
+            const command = new CommandOrEvent(dependencies);
+            command.category = category;
 
-          // Handle the object, throw an error if it does not extend Command or Event
-          if (commandOrEvent instanceof Command) {
-            commandOrEvent.category = category;
+            this.loadCommand(command);
+          } else if (CommandOrEvent.prototype instanceof Event) {
+            const event = new CommandOrEvent(dependencies);
 
-            this.loadCommand(commandOrEvent, file);
-          } else if (commandOrEvent instanceof Event) {
-            this.loadEvent(commandOrEvent);
-          } else {
-            // TODO: add a debug message here?
+            this.loadEvent(event);
           }
         });
     });


### PR DESCRIPTION
This fixes #26 by checking if `CommandOrEvent.prototype` is an instance of `Command` or `Event` instead of creating an instance.