### PR TITLE
Fixed issue with aliases not working

### DIFF
--- a/src/handler/Handler.js
+++ b/src/handler/Handler.js
@@ -182,8 +182,8 @@ class Handler {
 
       let cmd = this.commands.get(command.toLowerCase());
 
-      // If there is not command get the alias if found
       if (!cmd) {
+        // Get the command by alias
         cmd = this.aliases.get(command.toLowerCase());
       }
 

--- a/src/handler/Handler.js
+++ b/src/handler/Handler.js
@@ -180,10 +180,15 @@ class Handler {
       // Remove prefix and split message into command and args
       const [command, ...args] = message.content.slice(this.prefix.length).split(' ');
 
-      const cmd = new Map([...this.commands, ...this.aliases]).get(command.toLowerCase());
+      let cmd = this.commands.get(command.toLowerCase());
+
+      // If there is not command get the alias if found
+      if (!cmd) {
+        cmd = this.aliases.get(command.toLowerCase());
+      }
 
       if (!cmd || !cmd.isEnabled) {
-        // No command found or command is disabled
+        // No command or alias found or command is disabled
         return;
       }
 

--- a/src/handler/Handler.js
+++ b/src/handler/Handler.js
@@ -180,7 +180,8 @@ class Handler {
       // Remove prefix and split message into command and args
       const [command, ...args] = message.content.slice(this.prefix.length).split(' ');
 
-      const cmd = this.commands.get(command.toLowerCase());
+      const cmd = new Map([...this.commands, ...this.aliases]).get(command.toLowerCase());
+
       if (!cmd || !cmd.isEnabled) {
         // No command found or command is disabled
         return;


### PR DESCRIPTION
Fixed issue #35 where the aliases were not working properly.

I tried to use:
```js
const cmd = this.commands.get(command.toLowerCase()) || this.aliases.get(command.toLowerCase());
```
but it wouldn't pass the test, the only way it passed it was by making a new Map with both aliases and commands in it.