### PR TITLE
Add prettier for a stricter code style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,11 +3,15 @@ module.exports = {
     node: true,
     es6: true,
   },
-  extends: 'airbnb-base',
+  extends: [
+    'airbnb-base',
+    'plugin:prettier/recommended',
+  ],
   parserOptions: {
     ecmaVersion: 2019,
   },
   plugins: [
+    'prettier',
     'import',
     'jsdoc',
     'eslint-comments',
@@ -20,6 +24,9 @@ module.exports = {
     'no-restricted-syntax': 'off',
     'prefer-destructuring': 'off',
     'linebreak-style': 'off',
+
+    // prettier
+    'prettier/prettier': 'error',
 
     // import
     'import/no-cycle': 'off',

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  trailingComma: 'all',
+  singleQuote: true,
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node src/index.js",
     "test": "npm run lint",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "pretty": "prettier --write \"src/**/*.js\""
   },
   "repository": {
     "type": "git",
@@ -24,9 +24,12 @@
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-eslint-comments": "^3.1.1",
     "eslint-plugin-import": "^2.17.3",
-    "eslint-plugin-jsdoc": "^7.2.3"
+    "eslint-plugin-jsdoc": "^7.2.3",
+    "eslint-plugin-prettier": "^3.1.0",
+    "prettier": "1.18.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -10,17 +10,16 @@ class Utils {
   static readdirSyncRecursive(directory) {
     let files = [];
 
-    fs.readdirSync(directory)
-      .forEach((file) => {
-        const location = path.join(directory, file);
+    fs.readdirSync(directory).forEach(file => {
+      const location = path.join(directory, file);
 
-        // If the file is a directory read it recursively
-        if (fs.lstatSync(location).isDirectory()) {
-          files = files.concat(Utils.readdirSyncRecursive(location));
-        } else {
-          files.push(location);
-        }
-      });
+      // If the file is a directory read it recursively
+      if (fs.lstatSync(location).isDirectory()) {
+        files = files.concat(Utils.readdirSyncRecursive(location));
+      } else {
+        files.push(location);
+      }
+    });
 
     return files;
   }

--- a/src/handler/Command.js
+++ b/src/handler/Command.js
@@ -19,7 +19,7 @@ class Command extends Toggleable {
       throw new TypeError('Aliases must be an array');
     }
     if (options.aliases) {
-      options.aliases.forEach((alias) => {
+      options.aliases.forEach(alias => {
         if (typeof alias !== 'string') {
           throw new TypeError('Aliases array must contain strings only');
         }

--- a/src/handler/Feature.js
+++ b/src/handler/Feature.js
@@ -39,7 +39,7 @@ class Feature extends Toggleable {
    */
   registerCommand(command) {
     if (!(command instanceof Command)) {
-      throw new TypeError('Can\'t register command, it does not extend Command');
+      throw new TypeError("Can't register command, it does not extend Command");
     }
 
     this.commands.push(command);
@@ -51,7 +51,7 @@ class Feature extends Toggleable {
    */
   registerEvent(event) {
     if (!(event instanceof Event)) {
-      throw new TypeError('Can\'t register event, it does not extend Event');
+      throw new TypeError("Can't register event, it does not extend Event");
     }
 
     this.events.push(event);

--- a/src/handler/Handler.js
+++ b/src/handler/Handler.js
@@ -60,23 +60,23 @@ class Handler {
     this.dependencies = dependencies;
 
     // Find and require all JavaScript files
-    const nodes = Utils
-      .readdirSyncRecursive(directory)
+    const nodes = Utils.readdirSyncRecursive(directory)
       .filter(file => file.endsWith('.js'))
       .map(require);
 
     // Load all Features
-    nodes.forEach((Node) => {
+    nodes.forEach(Node => {
       if (Node.prototype instanceof Feature) {
         this.loadFeature(new Node(dependencies));
       }
     });
 
     // Load all Command and Event classes that haven't loaded yet
-    nodes.forEach((Node) => {
+    nodes.forEach(Node => {
       if (Node.prototype instanceof Command) {
-        const loaded = Array.from(this.commands.values())
-          .some(command => command instanceof Node);
+        const loaded = Array.from(this.commands.values()).some(
+          command => command instanceof Node,
+        );
 
         if (!loaded) {
           this.loadCommand(new Node(dependencies));
@@ -84,9 +84,9 @@ class Handler {
       }
 
       if (Node.prototype instanceof Event) {
-        const loaded = Array.from(this.events.values())
-          .some(events => events
-            .some(event => event instanceof Node));
+        const loaded = Array.from(this.events.values()).some(events =>
+          events.some(event => event instanceof Node),
+        );
 
         if (!loaded) {
           this.loadEvent(new Node(dependencies));
@@ -104,16 +104,18 @@ class Handler {
    */
   loadFeature(feature) {
     if (this.features.has(feature.name)) {
-      throw new Error(`Can't load Feature, the name '${feature.name}' is already used`);
+      throw new Error(
+        `Can't load Feature, the name '${feature.name}' is already used`,
+      );
     }
 
     this.features.set(feature.name, feature);
 
-    feature.commands.forEach((command) => {
+    feature.commands.forEach(command => {
       this.loadCommand(command);
     });
 
-    feature.events.forEach((event) => {
+    feature.events.forEach(event => {
       this.loadEvent(event);
     });
   }
@@ -125,15 +127,19 @@ class Handler {
   loadCommand(command) {
     // Command name might be in use or name might already be an existing alias
     if (this.commands.has(command.name) || this.aliases.has(command.name)) {
-      throw new Error(`Can't load command, the name '${command.name}' is already used as a command name or alias`);
+      throw new Error(
+        `Can't load command, the name '${command.name}' is already used as a command name or alias`,
+      );
     }
 
     this.commands.set(command.name, command);
 
-    command.aliases.forEach((alias) => {
+    command.aliases.forEach(alias => {
       // Alias might already be a command or might already be in use
       if (this.commands.has(alias) || this.aliases.has(alias)) {
-        throw new Error(`Can't load command, the alias '${alias}' is already used as a command name or alias`);
+        throw new Error(
+          `Can't load command, the alias '${alias}' is already used as a command name or alias`,
+        );
       }
 
       this.aliases.set(alias, command);
@@ -172,13 +178,15 @@ class Handler {
     }
 
     // Handle commands
-    this.client.on('message', async (message) => {
+    this.client.on('message', async message => {
       if (message.author.bot || !message.content.startsWith(this.prefix)) {
         return;
       }
 
       // Remove prefix and split message into command and args
-      const [command, ...args] = message.content.slice(this.prefix.length).split(' ');
+      const [command, ...args] = message.content
+        .slice(this.prefix.length)
+        .split(' ');
 
       const cmd = this.commands.get(command.toLowerCase());
       if (!cmd || !cmd.isEnabled) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,10 @@
 // Node version, if it isn't it throw the following error to inform
 // you.
 
-if (Number(process.version.slice(1).split('.')[0]) < 10) throw new Error('Node 10.0.0 or higher is required. Update Node on your system.');
+if (Number(process.version.slice(1).split('.')[0]) < 10)
+  throw new Error(
+    'Node 10.0.0 or higher is required. Update Node on your system.',
+  );
 
 const path = require('path');
 

--- a/src/modules/general/commands/ping.js
+++ b/src/modules/general/commands/ping.js
@@ -18,7 +18,9 @@ module.exports = class extends Command {
       return msg.edit('Please try again...');
     }
 
-    return msg.edit(`🏓 P${'o'.repeat(Math.ceil(ping / 100))}ng: \`${ping}ms\`\n`
-      + `💓 Heartbeat: \`${Math.round(message.client.ping)}ms\``);
+    return msg.edit(
+      `🏓 P${'o'.repeat(Math.ceil(ping / 100))}ng: \`${ping}ms\`\n` +
+        `💓 Heartbeat: \`${Math.round(message.client.ping)}ms\``,
+    );
   }
 };


### PR DESCRIPTION
This commits adds prettier (https://prettier.io/) to the repo. Using prettier allows the code to be formatted strictly and consistently without effort. Prettier also fills in gabs in ESLint regarding indentation and other style rules.

Prettier runs through ESLint on `npm run lint` to make sure the code is properly formatted.
Formatting the code can be done with `npm run pretty`.