### PR TITLE
Update issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,3 +24,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+---
+
+If you want to fix this bug, please open a draft pull request which references this issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,4 +27,4 @@ Add any other context about the problem here.
 
 ---
 
-If you want to fix this bug, please open a draft pull request which references this issue.
+If you want to implement a fix for this bug, please open a draft pull request which references this issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+---
+
+If you want to implement this feature request, please open a draft pull request which references this issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+<!-- ATTENTION! -->
+<!-- If you want to add a new command/event, please open a feature request issue first -->
+
+This pull request resolves #... <!-- replace '...' with the ID of the issue this PR is for -->
+
+---
+
+### Description
+Please explain what this PR changes. Please also include relevant motivation and context.


### PR DESCRIPTION
This PR changes the issue to include some additional information on how we want issues to be handled.

This also adds a PR template which provides the minimum information we need. `resolves #...` links to the issue this PR is for. Closing the PR will also autoclose the issue if it's linked.