### PR TITLE
Add the common-tags package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/The-SourceCode/Open-SourceBot#readme",
   "dependencies": {
+    "common-tags": "^1.8.0",
     "discord.js": "^11.5.1"
   },
   "devDependencies": {

--- a/src/modules/general/commands/ping.js
+++ b/src/modules/general/commands/ping.js
@@ -1,3 +1,5 @@
+const { stripIndents } = require('common-tags');
+
 const { Command } = require('../../../handler');
 
 module.exports = class extends Command {
@@ -19,8 +21,10 @@ module.exports = class extends Command {
     }
 
     return msg.edit(
-      `🏓 P${'o'.repeat(Math.ceil(ping / 100))}ng: \`${ping}ms\`\n` +
-        `💓 Heartbeat: \`${Math.round(message.client.ping)}ms\``,
+      stripIndents`
+      🏓 P${'o'.repeat(Math.ceil(ping / 100))}ng: \`${ping}ms\`
+      💓 Heartbeat: \`${Math.round(message.client.ping)}ms\`
+      `,
     );
   }
 };


### PR DESCRIPTION
This PR adds the [common-tags](https://www.npmjs.com/package/common-tags) package. This includes some handy functions to make working with strings easier.